### PR TITLE
Fix Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,13 +42,6 @@ matrix:
         - UNICODE_WIDTH=16
     - os: linux
       env:
-        - MB_PYTHON_VERSION=3.4
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=3.4
-        - PLAT=i686
-    - os: linux
-      env:
         - MB_PYTHON_VERSION=3.5
         - NP_BUILD_DEP=numpy==1.9.3
         - NP_TEST_DEP=numpy==1.9.3
@@ -96,12 +89,6 @@ matrix:
       language: generic
       env:
          - MB_PYTHON_VERSION=2.7
-    - os: osx
-      language: generic
-      env:
-        - MB_PYTHON_VERSION=3.4
-        - NP_BUILD_DEP=numpy==1.7.1
-        - NP_TEST_DEP=numpy==1.7.1
     - os: osx
       language: generic
       env:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,14 +28,6 @@ environment:
       PYTHON_VERSION: "2.7.x" # currently 2.7.11
       PYTHON_ARCH: "64"
 
-    - PYTHON: "C:\\Python34"
-      PYTHON_VERSION: "3.4.x" # currently 3.4.3
-      PYTHON_ARCH: "32"
-
-    - PYTHON: "C:\\Python34-x64"
-      PYTHON_VERSION: "3.4.x" # currently 3.4.3
-      PYTHON_ARCH: "64"
-
     - PYTHON: "C:\\Python35"
       PYTHON_VERSION: "3.5.x" # currently 3.5.1
       PYTHON_ARCH: "32"


### PR DESCRIPTION
This resolves https://github.com/pydata/numexpr/issues/351#issuecomment-568650361 by updating multibuild to [the latest commit on the master branch](https://github.com/matthew-brett/multibuild/commit/88a0b6f0eb770cf9f95792d66410e7696ce3d384). This also drops Python 3.4, which [reached its EOL in March 2019](https://www.python.org/dev/peps/pep-0429/).